### PR TITLE
Update information about SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ by [Email](mailto:pmwkaa@gmail.com).
 |---|---|---|---|---|
 | [Berkeley DB](http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html) | C | AGPLv3 or Proprietary | B-Tree, Hash | Berkeley DB (BDB) is a software library that provides a high-performance embedded database for key/value data. |
 | [Tokyo/Kyoto Cabinet](http://fallabs.com/kyotocabinet/) | C++ | GPLv2.1 / GPLv3 w/ compatibility exceptions | B-Tree, Hash | Tokyo Cabinet and Kyoto Cabinet are two libraries of routines for managing key-value databases. |
-| [SQLite](https://sqlite.org/) | C | Public Domain | B-Tree, LSM | SQLite is a relational database management system contained in a C programming library. |
+| [SQLite3](https://sqlite.org/) | C | Public Domain | B-Tree | SQLite is a relational database management system contained in a C programming library. |
 | [UnQLite](http://unqlite.org/) | C | 2-Clause BSD (Simplified) | Hash | UnQLite is a in-process software library which implements a self-contained, serverless, zero-configuration, transactional NoSQL database engine. |
 | [LevelDB](https://github.com/google/leveldb) | C++ | 3-Clause BSD (New/Revised) | LSM | LevelDB is an open source on-disk key-value store written by Google. |
 | [LevelDB by Basho](https://github.com/basho/leveldb) | C++ | 3-Clause BSD (New/Revised) | LSM | A fork of LevelDB modified to benefit the Riak environment. |


### PR DESCRIPTION
LSM was used only in experemental SQLite4. It is no longer developed
and there are no plans to resume development:
https://sqlite.org/src4/artifact/56683d66cbd41c2e

SQLite3 uses B-Tree:
https://sqlite.org/fileformat2.html#b_tree_pages